### PR TITLE
Use yaml.safe_load for config file parsing.

### DIFF
--- a/marteau/config.py
+++ b/marteau/config.py
@@ -315,4 +315,4 @@ class MarteauConfig(dict):
 def read_yaml_config(project_dir, filename='.marteau.yml'):
     config_file = os.path.join(project_dir, filename)
     with open(config_file) as f:
-        return MarteauConfig(yaml.load(f.read()))
+        return MarteauConfig(yaml.safe_load(f.read()))


### PR DESCRIPTION
yaml.load() allows arbitrary code execution in the same manner as pickle, so it seems better to use yaml.safe_load() in this context.

I don't think there's an actual security issue, since the whole point of marteau is to run arbitrary code.  But better safe than sorry...
